### PR TITLE
Add CoinGecko price change utility and test

### DIFF
--- a/src/tests/coinGeckoPriceChange.test.ts
+++ b/src/tests/coinGeckoPriceChange.test.ts
@@ -1,0 +1,43 @@
+import { fetchTokenPriceChange } from '../utils/coinGeckoPriceChange';
+import 'dotenv/config';
+
+async function PriceChangeTest() {
+    try {
+        // Test with a known token (e.g., bitcoin)
+        const tokenId = 'bitcoin';
+        const url = `https://api.coingecko.com/api/v3/simple/price?vs_currencies=usd&ids=${tokenId}&include_24hr_change=true&precision=5`;
+        
+        // Make raw fetch call to see full response
+        const headers: Record<string, string> = {
+            'accept': 'application/json',
+            'x-cg-demo-api-key': process.env.COINGECKO_API_KEY as string
+        };
+
+        console.log('Making API call to:', url);
+        const response = await fetch(url, { headers });
+        const rawText = await response.text();
+        
+        console.log('\nResponse Status:', response.status);
+        console.log('Response Headers:', Object.fromEntries(response.headers.entries()));
+        console.log('\nRaw Response Body:', rawText);
+        
+        try {
+            // Try parsing as JSON to see structured data
+            const jsonData = JSON.parse(rawText);
+            console.log('\nParsed JSON Response:', JSON.stringify(jsonData, null, 2));
+        } catch (e) {
+            console.log('Response is not valid JSON');
+        }
+
+        // Test the actual function
+        console.log('\nTesting fetchTokenPriceChange function:');
+        const result = await fetchTokenPriceChange(tokenId);
+        console.log('fetchTokenPriceChange result:', result);
+
+    } catch (error) {
+        console.error('Test failed:', error);
+    }
+}
+
+// Run the test
+PriceChangeTest().then(() => console.log('Test completed')); 

--- a/src/utils/coinGeckoPriceChange.ts
+++ b/src/utils/coinGeckoPriceChange.ts
@@ -1,0 +1,69 @@
+import 'dotenv/config';
+
+
+// Interface for the Coingecko API response
+interface CoinGeckoPriceChangeDetail {
+    usd_24h_change: number;
+}
+
+interface CoinGeckoPriceChangeResponse {
+  [tokenId: string]: CoinGeckoPriceChangeDetail;
+}
+
+const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY;
+
+if (!COINGECKO_API_KEY) {
+    throw new Error('COINGECKO_API_KEY is required but not set in environment variables');
+}
+
+/**
+ * Fetches the price change data for a specific token from CoinGecko
+ * @param tokenId The CoinGecko token ID (e.g., 'bitcoin')
+ * @returns The 24h price change percentage in USD
+ */
+export async function fetchTokenPriceChange(tokenId: string): Promise<number | null> {
+    const url = `https://api.coingecko.com/api/v3/simple/price?vs_currencies=usd&ids=${tokenId}&include_24hr_change=true&precision=5`;
+    
+    // We can safely assert this type since we checked COINGECKO_API_KEY is not undefined above
+    const headers: Record<string, string> = {
+        'accept': 'application/json',
+        'x-cg-demo-api-key': COINGECKO_API_KEY as string
+    };
+
+    const options: RequestInit = {
+        method: 'GET',
+        headers
+    };
+
+    try {
+        console.log(`[CoinGecko] Fetching price 24h change for token: ${tokenId}`);
+        const response = await fetch(url, options);
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            console.error('[CoinGecko] Failed to fetch token price 24h change', {
+                status: response.status,
+                statusText: response.statusText,
+                errorBody: errorBody,
+            });
+            return null;
+        }
+
+        const json = await response.json() as CoinGeckoPriceChangeResponse;
+        const tokenData = json[tokenId];
+
+        if (!tokenData || typeof tokenData.usd_24h_change !== 'number') {
+            console.warn('[CoinGecko] Received invalid or unexpected data structure', { response: json });
+            return null;
+        }
+
+        console.log(`[CoinGecko] Successfully fetched 24h price change for ${tokenId}: ${tokenData.usd_24h_change}%`);
+        return tokenData.usd_24h_change;
+    } catch (error) {
+        console.error('[CoinGecko] Error fetching or processing token 24h price change', { 
+            errorMessage: error instanceof Error ? error.message : 'Unknown error',
+            errorStack: error instanceof Error ? error.stack : undefined,
+        });
+        return null;
+    }
+} 


### PR DESCRIPTION
**This PR**
- Resolves : #4 

**New:**
- Implemented fetchTokenPriceChange function to retrieve 24h price change data for tokens from the CoinGecko API.
- Created a test file to validate the functionality of fetchTokenPriceChange, including logging of API responses and error handling.