### PR TITLE
Added `/price` endpoint

### DIFF
--- a/src/controller/priceController.ts
+++ b/src/controller/priceController.ts
@@ -1,0 +1,37 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { fetchTokenPrice } from "../utils/coinGeckoPrice";
+
+interface TokenPriceParams {
+  tokenId: string;
+}
+
+export default async function priceController(fastify: FastifyInstance) {
+  // GET /api/v1/price/:tokenId
+  fastify.get<{ Params: TokenPriceParams }>(
+    "/:tokenId",
+    async function (request: FastifyRequest<{ Params: TokenPriceParams }>, reply: FastifyReply) {
+      const { tokenId } = request.params;
+
+      try {
+        const priceData = await fetchTokenPrice(tokenId);
+        
+        if (!priceData) {
+          return reply.status(404).send({
+            success: false,
+            error: "404 Token price data not found"
+          });
+        }
+
+        return reply.send({
+          success: true,
+          price: priceData.usd
+        });
+      } catch (error) {
+        return reply.status(500).send({
+          success: false,
+          error: "Failed to fetch token price"
+        });
+      }
+    }
+  );
+} 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,8 +1,10 @@
 import { FastifyInstance } from "fastify";
 import userController from "./controller/userController";
 import indexController from "./controller/indexController";
+import priceController from "./controller/priceController";
 
 export default async function router(fastify: FastifyInstance) {
   fastify.register(userController, { prefix: "/api/v1/user" });
   fastify.register(indexController, { prefix: "/" });
+  fastify.register(priceController, { prefix: "/api/v1/price" });
 }


### PR DESCRIPTION
This PR is related to the first half of #6 

**What's New**

- Introduced priceController to handle GET requests for token prices at the endpoint /api/v1/price/:tokenId.
- Integrated fetchTokenPrice utility to retrieve price data from the CoinGecko API.
- Implemented error handling for cases where token price data is not found or if the fetch operation fails.