### PR TITLE
Added `/volume` endpoint

### DIFF
--- a/src/controller/volumeController.ts
+++ b/src/controller/volumeController.ts
@@ -1,0 +1,37 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { fetchTokenVolume } from "../utils/coinGeckoVolume";
+
+interface TokenVolumeParams {
+  tokenId: string;
+}
+
+export default async function volumeController(fastify: FastifyInstance) {
+  // GET /api/v1/volume/:tokenId
+  fastify.get<{ Params: TokenVolumeParams }>(
+    "/:tokenId",
+    async function (request: FastifyRequest<{ Params: TokenVolumeParams }>, reply: FastifyReply) {
+      const { tokenId } = request.params;
+
+      try {
+        const volumeData = await fetchTokenVolume(tokenId);
+        
+        if (!volumeData) {
+          return reply.status(404).send({
+            success: false,
+            error: "404 Token volume data not found"
+          });
+        }
+
+        return reply.send({
+          success: true,
+          volume: volumeData.usd_24h_vol
+        });
+      } catch (error) {
+        return reply.status(500).send({
+          success: false,
+          error: "Failed to fetch token volume"
+        });
+      }
+    }
+  );
+} 

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,9 +2,11 @@ import { FastifyInstance } from "fastify";
 import userController from "./controller/userController";
 import indexController from "./controller/indexController";
 import priceController from "./controller/priceController";
+import volumeController from "./controller/volumeController";
 
 export default async function router(fastify: FastifyInstance) {
   fastify.register(userController, { prefix: "/api/v1/user" });
   fastify.register(indexController, { prefix: "/" });
   fastify.register(priceController, { prefix: "/api/v1/price" });
+  fastify.register(volumeController, { prefix: "/api/v1/volume" });
 }


### PR DESCRIPTION
This PR addresses the second half of #6 
- Closes: #6 

**Whats New:**
- Introduced volumeController to handle GET requests for token volume at the endpoint /api/v1/volume/:tokenId.
- Integrated fetchTokenVolume utility to retrieve volume data from the CoinGecko API.
- Implemented error handling for cases where token volume data is not found or if the fetch operation fails.