### PR TITLE
Added `priceChange` endpoint

### DIFF
--- a/src/controller/priceChangeController.ts
+++ b/src/controller/priceChangeController.ts
@@ -1,0 +1,37 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { fetchTokenPriceChange } from "../utils/coinGeckoPriceChange";
+
+interface TokenPriceChangeParams {
+  tokenId: string;
+}
+
+export default async function priceChangeController(fastify: FastifyInstance) {
+  // GET /api/v1/priceChange/:tokenId
+  fastify.get<{ Params: TokenPriceChangeParams }>(
+    "/:tokenId",
+    async function (request: FastifyRequest<{ Params: TokenPriceChangeParams }>, reply: FastifyReply) {
+      const { tokenId } = request.params;
+
+      try {
+        const priceChangeData = await fetchTokenPriceChange(tokenId);
+        
+        if (!priceChangeData) {
+          return reply.status(404).send({
+            success: false,
+            error: "404 Token price change data not found"
+          });
+        }
+
+        return reply.send({
+          success: true,
+          priceChange: priceChangeData
+        });
+      } catch (error) {
+        return reply.status(500).send({
+          success: false,
+          error: "Failed to fetch token price change"
+        });
+      }
+    }
+  );
+} 

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,9 +2,11 @@ import { FastifyInstance } from "fastify";
 import userController from "./controller/userController";
 import indexController from "./controller/indexController";
 import priceController from "./controller/priceController";
+import priceChangeController from "./controller/priceChangeController";
 
 export default async function router(fastify: FastifyInstance) {
   fastify.register(userController, { prefix: "/api/v1/user" });
   fastify.register(indexController, { prefix: "/" });
   fastify.register(priceController, { prefix: "/api/v1/price" });
+  fastify.register(priceChangeController, { prefix: "/api/v1/priceChange" });
 }


### PR DESCRIPTION
**This PR:**

- Closes : #7 

**Whats New**

- Introduced priceChangeController to handle GET requests for token price changes at the endpoint `/api/v1/priceChange/tokenId`.
- Integrated fetchTokenPriceChange utility to retrieve 24h price change data from the CoinGecko API.
- Implemented error handling for cases where token price change data is not found or if the fetch operation fails.