### PR TITLE
Added `responses.ts` for standardizing response types

### DIFF
--- a/src/types/responses.ts
+++ b/src/types/responses.ts
@@ -1,0 +1,24 @@
+/**
+ * Type for API results with success/error status
+ */
+export type Result<T> =
+  | {
+      success: false;
+      error: string;
+      status: number;
+    }
+  | {
+      success: true;
+      data: T;
+    };
+
+/**
+ * Type for API responses with data/error
+ */
+export type Response<T> =
+  | {
+      error: string;
+    }
+  | {
+      data: T;
+    }; 


### PR DESCRIPTION
This PR is the first part of #47 

- Introduced Result and Response types in src/types/responses.ts to standardize API result structures.
- Result type encapsulates success and error states with relevant data.
- Response type provides a consistent format for API responses, including error and data fields.

