### PR TITLE
Feat: prisma migration for API keys

### DIFF
--- a/prisma/migrations/20250717151120_add_api_keys/migration.sql
+++ b/prisma/migrations/20250717151120_add_api_keys/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ApiKey_key_key" ON "ApiKey"("key");
+
+-- AddForeignKey
+ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   alerts    Alert[]
+  apiKeys   ApiKey[]
 }
 
 model Token {
@@ -51,4 +52,15 @@ model PriceAlert {
   value     Float
   alertId   String              @unique
   alert     Alert               @relation("AlertToPriceAlert", fields: [alertId], references: [id])
+}
+
+model ApiKey {
+  id          String   @id @default(uuid())
+  key         String   @unique
+  name        String
+  createdAt   DateTime @default(now())
+  lastUsedAt  DateTime @default(now())
+  isActive    Boolean  @default(true)
+  userId      String
+  user        User     @relation(fields: [userId], references: [id])
 }


### PR DESCRIPTION
This pr is the start of #45 

- adds the `ApiKey` table to the schema
- migrated the scema