### PR TITLE
Feat: Api Route and request field change

### DIFF
--- a/src/controller/api/apiKeyController.ts
+++ b/src/controller/api/apiKeyController.ts
@@ -1,19 +1,14 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { z } from "zod";
-import bcrypt from "bcrypt";
 import crypto from "crypto";
 import { prisma } from "../../utils/prisma";
 import { Response } from "../../types/responses";
 
 // Define the API key request schema
 const apiKeyRequestSchema = z.object({
-  email: z.string({
-    required_error: "Email is required",
-    invalid_type_error: "Email must be a string"
-  }).email("Invalid email format"),
-  password: z.string({
-    required_error: "Password is required",
-    invalid_type_error: "Password must be a string"
+  userId: z.string({
+    required_error: "User ID is required",
+    invalid_type_error: "User ID must be a string"
   })
 });
 
@@ -43,28 +38,17 @@ export default async function apiKeyController(fastify: FastifyInstance) {
         // Validate the request body against the schema
         const validatedData = apiKeyRequestSchema.parse(request.body);
 
-        // Find user by email
+        // Find user by ID
         const user = await prisma.user.findUnique({
           where: {
-            email: validatedData.email
+            id: validatedData.userId
           }
         });
 
         // If user doesn't exist, return error
         if (!user) {
           const response: Response<ApiKeyResponse> = {
-            error: "Invalid credentials"
-          };
-          return reply.code(401).send(response);
-        }
-
-        // Compare password with hashed password
-        const isValidPassword = await bcrypt.compare(validatedData.password, user.password);
-
-        // If password is invalid, return error
-        if (!isValidPassword) {
-          const response: Response<ApiKeyResponse> = {
-            error: "Invalid credentials"
+            error: "Invalid user ID"
           };
           return reply.code(401).send(response);
         }

--- a/src/controller/api/index.ts
+++ b/src/controller/api/index.ts
@@ -1,0 +1,1 @@
+export { default as apiKeyController } from './apiKeyController'; 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from "fastify";
 import rateLimit from '@fastify/rate-limit';
 import { loginController, registerController } from "./controller/auth";
+import { apiKeyController } from "./controller/api";
 import userController from "./controller/userController";
 import indexController from "./controller/indexController";
 import priceController from "./controller/priceController";
@@ -20,6 +21,16 @@ export default async function router(fastify: FastifyInstance) {
     fastify.register(loginController);
     fastify.register(registerController);
   }, { prefix: "/auth" });
+  
+  // API key management endpoints with rate limiting
+  fastify.register(async (fastify) => {
+    await fastify.register(rateLimit, {
+      max: 5,
+      timeWindow: '1 minute'
+    });
+    
+    fastify.register(apiKeyController);
+  }, { prefix: "/api/v1/keys" });
   
   fastify.register(userController, { prefix: "/user" });
   


### PR DESCRIPTION
Now the request requires **userId** instead of **email and password**, as requested in #51.

- added API generation route in `api/v1/keys/generate`
- added rate limit of 5 per minute

This PR should 
- Resolve : #45 