### PR TITLE
Fix : Reverted the api authentication to use email and password

### DIFF
--- a/src/controller/api/apiKeyController.ts
+++ b/src/controller/api/apiKeyController.ts
@@ -1,35 +1,36 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { z } from "zod";
+import bcrypt from "bcrypt";
 import crypto from "crypto";
 import { prisma } from "../../utils/prisma";
 import { Response } from "../../types/responses";
 
 // Define the API key request schema
 const apiKeyRequestSchema = z.object({
-  userId: z.string({
-    required_error: "User ID is required",
-    invalid_type_error: "User ID must be a string"
+  email: z.string({
+    required_error: "Email is required",
+    invalid_type_error: "Email must be a string"
+  }).email("Invalid email format"),
+  password: z.string({
+    required_error: "Password is required",
+    invalid_type_error: "Password must be a string"
   })
 });
 
 // Type inference from the Zod schema
 type ApiKeyRequest = z.infer<typeof apiKeyRequestSchema>;
-
 // Type for API key response
 interface ApiKeyResponse {
   apiKey: string;
 }
-
 // Generate a secure API key
 function generateApiKey(): string {
   return `rdr_${crypto.randomBytes(32).toString('hex')}`;
 }
-
 // Generate a default name for the API key
 function generateKeyName(): string {
   return `API Key - ${new Date().toISOString()}`;
 }
-
 export default async function apiKeyController(fastify: FastifyInstance) {
   fastify.post<{ Body: ApiKeyRequest }>(
     "/generate",
@@ -38,10 +39,10 @@ export default async function apiKeyController(fastify: FastifyInstance) {
         // Validate the request body against the schema
         const validatedData = apiKeyRequestSchema.parse(request.body);
 
-        // Find user by ID
+        // Find user by email
         const user = await prisma.user.findUnique({
           where: {
-            id: validatedData.userId
+            email: validatedData.email
           }
         });
 
@@ -49,11 +50,22 @@ export default async function apiKeyController(fastify: FastifyInstance) {
         if (!user) {
           const response: Response<ApiKeyResponse> = {
             success: false,
-            error: "Invalid user ID"
+            error: "Invalid credentials"
           };
           return reply.code(401).send(response);
         }
 
+        // Compare password with hashed password
+        const isValidPassword = await bcrypt.compare(validatedData.password, user.password);
+
+        // If password is invalid, return error
+        if (!isValidPassword) {
+          const response: Response<ApiKeyResponse> = {
+            success: false,
+            error: "Invalid credentials"
+          };
+          return reply.code(401).send(response);
+        }
         // Generate and store new API key
         const apiKey = generateApiKey();
         const newApiKey = await prisma.apiKey.create({
@@ -63,7 +75,6 @@ export default async function apiKeyController(fastify: FastifyInstance) {
             userId: user.id
           }
         });
-
         // Return the API key
         const response: Response<ApiKeyResponse> = {
           success: true,
@@ -81,7 +92,6 @@ export default async function apiKeyController(fastify: FastifyInstance) {
           };
           return reply.code(400).send(response);
         }
-
         // Handle unexpected errors
         console.error('API key generation error:', error);
         const response: Response<ApiKeyResponse> = {
@@ -92,4 +102,4 @@ export default async function apiKeyController(fastify: FastifyInstance) {
       }
     }
   );
-} 
+}


### PR DESCRIPTION
Refactor apiKeyController to use email and password for API key generation

- Updated request schema to require email and password instead of userId.
- Enhanced user validation by checking credentials against the database.
- Integrated bcrypt for password comparison to ensure secure authentication.
- Improved error handling for invalid credentials during API key generation.