### PR TITLE
Feat: Implement getApiKeysController for API key retrieval

### DIFF
--- a/src/controller/api/getApiKeysController.ts
+++ b/src/controller/api/getApiKeysController.ts
@@ -1,0 +1,109 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { z } from "zod";
+import bcrypt from "bcrypt";
+import { prisma } from "../../utils/prisma";
+import { Response } from "../../types/responses";
+
+// Define the request schema
+const getApiKeysRequestSchema = z.object({
+  email: z.string({
+    required_error: "Email is required",
+    invalid_type_error: "Email must be a string"
+  }).email("Invalid email format"),
+  password: z.string({
+    required_error: "Password is required",
+    invalid_type_error: "Password must be a string"
+  })
+});
+
+// Type inference from the Zod schema
+type GetApiKeysRequest = z.infer<typeof getApiKeysRequestSchema>;
+
+// Type for API key list response
+interface ApiKeyListResponse {
+  apiKeys: {
+    id: string;
+    key: string;
+    createdAt: Date;
+    isActive: boolean;
+  }[];
+}
+
+export default async function getApiKeysController(fastify: FastifyInstance) {
+  fastify.post<{ Body: GetApiKeysRequest }>(
+    "/getApiKeys",
+    async function (request: FastifyRequest<{ Body: GetApiKeysRequest }>, reply: FastifyReply) {
+      try {
+        // Validate the request body against the schema
+        const validatedData = getApiKeysRequestSchema.parse(request.body);
+
+        // Find user by email
+        const user = await prisma.user.findUnique({
+          where: {
+            email: validatedData.email
+          }
+        });
+
+        // If user doesn't exist, return error
+        if (!user) {
+          const response: Response<ApiKeyListResponse> = {
+            success: false,
+            error: "Invalid credentials"
+          };
+          return reply.code(401).send(response);
+        }
+
+        // Compare password with hashed password
+        const isValidPassword = await bcrypt.compare(validatedData.password, user.password);
+
+        // If password is invalid, return error
+        if (!isValidPassword) {
+          const response: Response<ApiKeyListResponse> = {
+            success: false,
+            error: "Invalid credentials"
+          };
+          return reply.code(401).send(response);
+        }
+
+        // Fetch API keys for the user
+        const apiKeys = await prisma.apiKey.findMany({
+          where: {
+            userId: user.id
+          },
+          select: {
+            id: true,
+            key: true,
+            createdAt: true,
+            isActive: true
+          }
+        });
+
+        // Return the API keys
+        const response: Response<ApiKeyListResponse> = {
+          success: true,
+          data: {
+            apiKeys
+          }
+        };
+        return reply.code(200).send(response);
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          // Return validation errors
+          const response: Response<ApiKeyListResponse> = {
+            success: false,
+            error: error.errors[0].message
+          };
+          return reply.code(400).send(response);
+        }
+
+        // Handle unexpected errors
+        console.error('API key fetch error:', error);
+        const response: Response<ApiKeyListResponse> = {
+          success: false,
+          error: "Internal server error"
+        };
+        return reply.code(500).send(response);
+      }
+    }
+  );
+} 


### PR DESCRIPTION
This PR is regarding the first half of #46 
In this PR I've :
- Added a new controller to handle API key requests using email and password authentication.
- Integrated Zod for request validation and bcrypt for secure password comparison.
- Enhanced error handling for invalid credentials and validation errors.
- Returns a list of API keys associated with the authenticated user upon successful validation.
