### PR TITLE
Refactor: Move API key validation schemas to a separate module

### DIFF
--- a/src/controller/api/apiKeyController.ts
+++ b/src/controller/api/apiKeyController.ts
@@ -5,51 +5,14 @@ import crypto from "crypto";
 import { prisma } from "../../utils/prisma";
 import { Response } from "../../types/responses";
 import { handleControllerError } from "../../utils/responseHelper";
-
-const apiKeyRequestSchema = z.object({
-  email: z.string({
-    required_error: "Email is required",
-    invalid_type_error: "Email must be a string"
-  }).email("Invalid email format"),
-  password: z.string({
-    required_error: "Password is required",
-    invalid_type_error: "Password must be a string"
-  })
-});
-
-const deleteApiKeyRequestSchema = z.object({
-  email: z.string({
-    required_error: "Email is required",
-    invalid_type_error: "Email must be a string"
-  }).email("Invalid email format"),
-  password: z.string({
-    required_error: "Password is required",
-    invalid_type_error: "Password must be a string"
-  }),
-  apiKeyId: z.string({
-    required_error: "API key ID is required",
-    invalid_type_error: "API key ID must be a string"
-  }).uuid("Invalid API key ID format")
-});
-
-const updateApiKeyRequestSchema = z.object({
-  email: z.string({
-    required_error: "Email is required",
-    invalid_type_error: "Email must be a string"
-  }).email("Invalid email format"),
-  password: z.string({
-    required_error: "Password is required",
-    invalid_type_error: "Password must be a string"
-  }),
-  name: z.string({
-    required_error: "API key name is required",
-    invalid_type_error: "API key name must be a string"
-  }).min(1, "API key name cannot be empty").max(100, "API key name cannot exceed 100 characters")
-});
-
-type ApiKeyRequest = z.infer<typeof apiKeyRequestSchema>;
-type DeleteApiKeyRequest = z.infer<typeof deleteApiKeyRequestSchema>;
-type UpdateApiKeyRequest = z.infer<typeof updateApiKeyRequestSchema>;
+import { 
+  apiKeyRequestSchema, 
+  deleteApiKeyRequestSchema, 
+  updateApiKeyRequestSchema,
+  type ApiKeyRequest,
+  type DeleteApiKeyRequest,
+  type UpdateApiKeyRequest
+} from "../../lib/api/schemas";
 
 interface ApiKeyResponse {
   apiKey: string;

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+
+export const apiKeyRequestSchema = z.object({
+  email: z.string({
+    required_error: "Email is required",
+    invalid_type_error: "Email must be a string"
+  }).email("Invalid email format"),
+  password: z.string({
+    required_error: "Password is required",
+    invalid_type_error: "Password must be a string"
+  })
+});
+
+export const deleteApiKeyRequestSchema = z.object({
+  email: z.string({
+    required_error: "Email is required",
+    invalid_type_error: "Email must be a string"
+  }).email("Invalid email format"),
+  password: z.string({
+    required_error: "Password is required",
+    invalid_type_error: "Password must be a string"
+  }),
+  apiKeyId: z.string({
+    required_error: "API key ID is required",
+    invalid_type_error: "API key ID must be a string"
+  }).uuid("Invalid API key ID format")
+});
+
+
+export const updateApiKeyRequestSchema = z.object({
+  email: z.string({
+    required_error: "Email is required",
+    invalid_type_error: "Email must be a string"
+  }).email("Invalid email format"),
+  password: z.string({
+    required_error: "Password is required",
+    invalid_type_error: "Password must be a string"
+  }),
+  name: z.string({
+    required_error: "API key name is required",
+    invalid_type_error: "API key name must be a string"
+  }).min(1, "API key name cannot be empty").max(100, "API key name cannot exceed 100 characters")
+});
+
+
+export type ApiKeyRequest = z.infer<typeof apiKeyRequestSchema>;
+export type DeleteApiKeyRequest = z.infer<typeof deleteApiKeyRequestSchema>;
+export type UpdateApiKeyRequest = z.infer<typeof updateApiKeyRequestSchema>;


### PR DESCRIPTION
- Extracted API key request, deletion, and update schemas into a new `schemas.ts` file for better organization and reusability.
- Updated the API key controller to import schemas from the new module, improving code clarity and maintainability.